### PR TITLE
feat: add responsive hamburger menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,39 @@
 .read-the-docs {
   color: #888;
 }
+/* Navigation styles */
+.navbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .navbar ul {
+    display: none;
+  }
+  .navbar ul.open {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .hamburger {
+    display: block;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,26 @@ import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   return (
     <>
+      <nav className="navbar">
+        <button
+          className="hamburger"
+          aria-label="Toggle navigation menu"
+          aria-controls="primary-navigation"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          &#9776;
+        </button>
+        <ul id="primary-navigation" className={menuOpen ? 'open' : ''}>
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
       <div>
         <a href="https://vite.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />


### PR DESCRIPTION
## Summary
- add state-driven hamburger button and navigation list
- style hamburger and menu for small-screen responsiveness
- provide aria attributes for accessible toggle

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68927ed44c38832ba5170c3e0944f738