### PR TITLE
fix: normalize prairie grass scaling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,7 +84,7 @@ body {
   bottom: 60px;
   left: 0;
   width: 100%;
-  height: 120px;
+  height: 180px;
   z-index: 999;
 }
 


### PR DESCRIPTION
## Summary
- reset canvas transform before DPR scaling
- size grass blades relative to canvas height and add natural variance
- increase prairie grass strip height for better fit

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68954e9d8404832b9d15e19ba753d9ed