### PR TITLE
feat: align carousel to left and adjust scroll direction

### DIFF
--- a/src/components/Carousel.css
+++ b/src/components/Carousel.css
@@ -5,7 +5,7 @@
   overflow: hidden;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   perspective: 1000px;
   perspective-origin: center center;
 }
@@ -14,8 +14,8 @@
   position: relative;
   width: 500px;
   height: 500px;
-  /* Center the wheel instead of shifting left */
-  transform: translateX(0);
+  /* Position wheel so only right half is visible */
+  transform: translateX(-250px);
   transform-style: preserve-3d;
 }
 
@@ -122,7 +122,7 @@
   border: 1px dashed rgba(85, 107, 47, 0.08);
   border-radius: 50%;
   pointer-events: none;
-  transform: translateX(0);
+  transform: translateX(-250px);
   background: radial-gradient(
     circle at center,
     rgba(85, 107, 47, 0.03),

--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -120,11 +120,12 @@ const Carousel = () => {
     const handleWheel = (e) => {
       e.preventDefault();
       if (isTransitioning) return;
-      
+
+      // Match card movement to scroll direction
       if (e.deltaY > 0) {
-        rotateWheel(1);
-      } else {
         rotateWheel(-1);
+      } else {
+        rotateWheel(1);
       }
     };
 

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -45,7 +45,8 @@
 
 .carousel-wrapper {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  overflow: hidden;
 }
 
 .headshot-wrapper {
@@ -81,7 +82,7 @@
   }
   
   .carousel-wrapper {
-    justify-content: center;
+    justify-content: flex-start;
   }
   
   .headshot-wrapper {


### PR DESCRIPTION
## Summary
- fix carousel wheel to move with scroll direction
- shift carousel wheel left so only right half is visible
- left-align carousel wrapper on home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ebda3778832b81594eb66a343968