### PR TITLE
fix rock layering and canvas scaling

### DIFF
--- a/src/components/GroundNav.css
+++ b/src/components/GroundNav.css
@@ -20,6 +20,7 @@
   width: 100%; height: 80px;
   pointer-events: none;
   filter: drop-shadow(0 2px 3px rgba(0,0,0,0.15));
+  z-index: 0;                   /* behind everything else in the bar */
 }
 
 .ground-inner {
@@ -47,7 +48,7 @@
   width: 100%;
   max-width: 800px;
   position: relative;
-  z-index: 2;                    /* above rocks canvas */
+  z-index: 3;                   /* above canvas */
 }
 
 .nav-list li {
@@ -86,5 +87,10 @@
 .ground-rocks {
   position: absolute;
   inset: 0;
-  z-index: 1;                    /* behind links */
+  z-index: 2;                   /* above background, below links */
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;         /* canvas can receive pointerdown */
+  touch-action: none;           /* allows smooth dragging on touch */
 }

--- a/src/components/GroundNav.jsx
+++ b/src/components/GroundNav.jsx
@@ -148,11 +148,13 @@ export default function GroundNav() {
     const resize = () => {
       const w = cvs.clientWidth;
       const h = cvs.clientHeight;
-      cvs.width = w * dpr;
-      cvs.height = h * dpr;
+      cvs.width = Math.round(w * dpr);
+      cvs.height = Math.round(h * dpr);
       cvs.style.width = `${w}px`;
       cvs.style.height = `${h}px`;
-      ctx.scale(dpr, dpr);
+
+      // IMPORTANT: reset & set DPR in one step (no accumulation)
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       return { w, h };
     };
     


### PR DESCRIPTION
## Summary
- layer ground nav elements so rocks render between background and nav links while nav stays clickable
- reset canvas transforms using device pixel ratio to prevent scale accumulation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fc8521644832b97de4fc9368866cd