### PR TITLE
Fix ground ridge seam and restyle nav buttons

### DIFF
--- a/src/components/GroundNav.css
+++ b/src/components/GroundNav.css
@@ -1,45 +1,48 @@
 /* Root variables */
 :root {
-  --ground-color: #8b7355;
-  --ground-dark: #9a8c73;
-  --ground-nav-height: 120px;
-  --nav-gap: 12px;
-  --nav-pad-x: 16px;
+  --ground-color: #c4b5a0;
+  --ground-dark:  #9a8c73;
 }
 
 /* Ground navigation bar */
 .ground-nav {
   position: fixed;
   left: 0; right: 0; bottom: 0;
-  height: var(--ground-nav-height);
-  z-index: 3000;
-  isolation: isolate;
-  pointer-events: none;
-  background: var(--ground-color);
+  height: 120px;                 /* keep existing height if different */
+  z-index: 3000;                 /* sit above grass/sky */
+  isolation: isolate;            /* independent stacking context */
+  pointer-events: none;          /* children opt in */
+  background: var(--ground-color); /* backfill to match SVG */
 }
 
-/* Background ridge behind everything in the bar */
+/* Ridge: remove edge artifact by overlapping and avoiding inline baseline */
 .ground-ridge {
   position: absolute;
-  top: -49px;
-  left: 0; right: 0;
-  width: 100%; height: 81px;
-  z-index: 0;
+  left: -1px; right: -1px;       /* tiny horizontal bleed */
+  top: -3px; bottom: -12px;      /* overlap into the bar to cover AA edge */
+  width: 100%;
+  display: block;                /* no inline baseline gap */
   pointer-events: none;
-  filter: drop-shadow(0 2px 3px rgba(0,0,0,0.15));
-  display: block;
-  transform: translateY(2px);
+  /* IMPORTANT: remove drop shadow here; it darkens the boundary and reads as a line */
+  filter: none;
 }
 
-/* Rocks canvas BETWEEN ridge and links; receives drag */
+/* Last safety backfill just under the ridge, inside the bar */
+.ground-nav::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 0;
+  height: 10px;
+  background: var(--ground-color);
+  z-index: 1;                    /* below canvas/links */
+  pointer-events: none;
+}
+
+/* Canvas stays between ridge and links */
 .ground-rocks {
   position: absolute;
-  left: 0; right: 0;
-  top: -48px;
-  height: calc(100% + 48px);
-  z-index: 2;
-  width: 100%;
-  display: block;
+  inset: 0;
+  z-index: 1;                    /* behind links */
   pointer-events: auto;
   touch-action: none;
 }
@@ -48,49 +51,60 @@
 .ground-inner {
   position: absolute;
   inset: 0;
-  z-index: 3;
+  z-index: 2;                    /* above canvas */
   pointer-events: auto;
   display: grid;
-  grid-template-rows: 1fr auto;
+  grid-template-rows: 1fr auto;  /* bottom row for nav */
+  background:
+    radial-gradient(1px 1px at 20% 30%, rgba(0,0,0,0.12) 0 40%, transparent 41%) repeat,
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,0.10) 0 45%, transparent 46%) repeat,
+    linear-gradient(to bottom, var(--ground-color), var(--ground-dark));
+  background-size: 180px 120px, 220px 150px, 100% 100%;
 }
 
-/* Put the nav buttons along the bottom band, spaced evenly */
 .nav-list {
-  grid-row: 2;
+  grid-row: 2;                   /* bottom row */
   display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  gap: var(--nav-gap);
-  padding: 8px var(--nav-pad-x) 10px;
-  position: relative;
+  justify-content: space-evenly; /* distribute across bottom band */
+  align-items: flex-end;         /* anchor to the edge */
+  gap: 12px;
+  padding: 0 16px 12px;          /* bottom padding = “on the band” */
   list-style: none;
   margin: 0;
+  width: 100%;
+  max-width: 900px;
+  z-index: 3;                    /* above canvas */
 }
 
-/* Buttons/links themselves */
-.nav-link {
+.ground-inner a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 72px;
   min-height: 40px;
   padding: 8px 14px;
-  border-radius: 10px;
   text-decoration: none;
+  font-weight: 600;
+  color: #2a2a22;
+  border-radius: 16px;
+  /* soft “feathered” look */
+  background: rgba(255,255,255,0.22);
+  border: 1px solid rgba(255,255,255,0.35);
+  box-shadow:
+    0 10px 22px rgba(0,0,0,0.16),
+    inset 0 0 0 0.75px rgba(255,255,255,0.28);
+  backdrop-filter: blur(4px);
+  transition: transform .2s ease, box-shadow .2s ease, background .2s ease;
   cursor: pointer;
-  backdrop-filter: blur(2px);
-  background: rgba(255,255,255,0.28);
-  color: #1a1a1a;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
 }
 
-/* hover/active/focus */
-.nav-link:hover { transform: translateY(-1px); }
-.nav-link:active { transform: translateY(0); filter: brightness(0.98); }
-.nav-link:focus-visible { outline: 2px solid rgba(0,0,0,0.45); outline-offset: 2px; }
-
-.nav-link[aria-current="page"] {
-  background: rgba(255,255,255,0.38);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+.ground-inner a:hover { transform: translateY(-2px); background: rgba(255,255,255,0.30); }
+.ground-inner a:active { transform: translateY(-1px); }
+.ground-inner a:focus-visible { outline: 2px solid rgba(0,0,0,0.45); outline-offset: 2px; }
+.ground-inner a[aria-current="page"] {
+  background: rgba(255,255,255,0.32);
+  box-shadow:
+    0 12px 24px rgba(0,0,0,0.18),
+    inset 0 0 0 0.75px rgba(255,255,255,0.34);
 }
 

--- a/src/components/GroundNav.jsx
+++ b/src/components/GroundNav.jsx
@@ -336,23 +336,26 @@ export default function GroundNav() {
 
   return (
     <div className="ground-nav">
-      <svg 
+      <svg
         ref={svgRef}
         className="ground-ridge"
-        viewBox="0 0 1200 80" 
-        preserveAspectRatio="none" 
+        viewBox="0 0 1200 80"
+        preserveAspectRatio="none"
+        shapeRendering="crispEdges"
+        style={{ display: 'block' }}
         aria-hidden="true"
       >
         <path
-          d="M0,55 
-             C80,35 120,25 200,45 
-             C280,65 320,20 400,35 
-             C480,50 520,15 600,40 
-             C680,65 720,25 800,30 
-             C880,35 920,55 1000,25 
-             C1080,10 1140,35 1200,40 
+          d="M0,55
+             C80,35 120,25 200,45
+             C280,65 320,20 400,35
+             C480,50 520,15 600,40
+             C680,65 720,25 800,30
+             C880,35 920,55 1000,25
+             C1080,10 1140,35 1200,40
              L1200,80 L0,80 Z"
           fill="var(--ground-color)"
+          stroke="none"
         />
       </svg>
       <canvas ref={canvasRef} className="ground-rocks" aria-hidden="true" />
@@ -360,11 +363,11 @@ export default function GroundNav() {
       <div className="ground-inner">
         <nav role="navigation" aria-label="Primary">
           <ul className="nav-list">
-            {navLinks.map((link, index) => {
+            {navLinks.map((link) => {
               const isCurrent = currentHash === link.href;
               return (
                 <li key={link.href}>
-                  <a 
+                  <a
                     className="nav-link"
                     href={link.href}
                     aria-current={isCurrent ? "page" : undefined}


### PR DESCRIPTION
## Summary
- Remove seam between ridge SVG and nav bar by overlapping and backfilling layers
- Restyle ground nav buttons along bottom band with soft borders and gradient background
- Add crisp edge rendering for ridge SVG and explicit stroke removal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25df3d818832bb9faace3e21f9141